### PR TITLE
🔒 fix cleanTeam nested activity code redaction

### DIFF
--- a/src/logic/cleanTeam.ts
+++ b/src/logic/cleanTeam.ts
@@ -4,12 +4,20 @@
  * Hotfix so a bit of a hack!
  */
 import { Team } from "@/models/Team";
+import { TeamActivity } from "@/models/TeamActivity";
 
 export function cleanTeam(team: Team): Team {
-  const cleanedTeam = { ...team, code: "XXXXXX" };
-  cleanedTeam.board = cleanedTeam.board.map((teamActivity) => {
-    const cleanedActivity = { ...teamActivity, code: "XXXXXX" };
-    return cleanedActivity;
-  });
-  return cleanedTeam;
+  const REDACTED_CODE = "XXXXXX";
+
+  return {
+    ...team,
+    code: REDACTED_CODE,
+    board: team.board.map((teamActivity: TeamActivity) => ({
+      ...teamActivity,
+      activity: {
+        ...teamActivity.activity,
+        code: REDACTED_CODE,
+      },
+    })),
+  };
 }


### PR DESCRIPTION
 ### Description
  Fix `cleanTeam` to correctly redact nested activity answer codes before team data is sent to the frontend.

  Previously, `cleanTeam` masked `teamActivity.code` (non-existent field) instead of `teamActivity.activity.code`, which
  could expose activity answer codes.

  Changes made:
  - Keep masking `team.code`.
  - Correctly mask `team.board[*].activity.code`.

  Closes
  N/A

  ### How To Review
  1. Review `src/logic/cleanTeam.ts`.
  2. Confirm redaction applies to both `team.code` and nested `activity.code`.
  3. Confirm no type/interface shape changes were introduced.